### PR TITLE
Replace \dt with \dt * to resolve "Did not find any relations" error on MacOS

### DIFF
--- a/scripts/sql/postgres/list-trustrydb.sql
+++ b/scripts/sql/postgres/list-trustrydb.sql
@@ -3,4 +3,4 @@
 \set ON_ERROR_STOP on
 
 \c trustydb
-\dt
+\dt *


### PR DESCRIPTION
When running `make start-sql`, it throws "Did not find any relations" on MacOS. The reason is behind a specific usage of \dt against an empty database.

Running Fmt
*** Building trusty
*** Building trustyctl
*** Building tool
*** Building kubeca
Running vet
Running lint
Running test
ok      github.com/ekspand/trusty/api/v1        (cached)
ok      github.com/ekspand/trusty/api/v1/pb     (cached)
?       github.com/ekspand/trusty/api/v1/pb/gw  [no test files]
ok      github.com/ekspand/trusty/authority     (cached)
ok      github.com/ekspand/trusty/backend/service       (cached)
ok      github.com/ekspand/trusty/backend/service/auth  3.612s
ok      github.com/ekspand/trusty/backend/service/ca    (cached)
ok      github.com/ekspand/trusty/backend/service/cis   (cached)
ok      github.com/ekspand/trusty/backend/service/ra    (cached)
ok      github.com/ekspand/trusty/backend/service/status        (cached)
ok      github.com/ekspand/trusty/backend/service/swagger       (cached)
?       github.com/ekspand/trusty/backend/service/workflow      [no test files]
ok      github.com/ekspand/trusty/backend/trustymain    4.300s
ok      github.com/ekspand/trusty/cli   (cached)
ok      github.com/ekspand/trusty/cli/auth      (cached)
ok      github.com/ekspand/trusty/cli/ca        (cached)
ok      github.com/ekspand/trusty/cli/certutil  (cached)
ok      github.com/ekspand/trusty/cli/cis       (cached)
ok      github.com/ekspand/trusty/cli/csr       (cached)
ok      github.com/ekspand/trusty/cli/hsm       (cached)
ok      github.com/ekspand/trusty/cli/status    (cached)
ok      github.com/ekspand/trusty/cli/testsuite (cached)
ok      github.com/ekspand/trusty/client        (cached)
?       github.com/ekspand/trusty/client/embed  [no test files]
ok      github.com/ekspand/trusty/client/embed/proxy    (cached)
?       github.com/ekspand/trusty/cmd/kubeca    [no test files]
?       github.com/ekspand/trusty/cmd/kubecertinit      [no test files]
ok      github.com/ekspand/trusty/cmd/trusty    (cached)
ok      github.com/ekspand/trusty/cmd/trusty-tool       (cached)
ok      github.com/ekspand/trusty/cmd/trustyctl (cached)
ok      github.com/ekspand/trusty/internal/appcontainer (cached)
ok      github.com/ekspand/trusty/internal/config       (cached)
ok      github.com/ekspand/trusty/internal/db   (cached)
ok      github.com/ekspand/trusty/internal/db/model     (cached)
ok      github.com/ekspand/trusty/internal/db/pgsql     (cached)
?       github.com/ekspand/trusty/internal/events       [no test files]
ok      github.com/ekspand/trusty/internal/version      (cached)
ok      github.com/ekspand/trusty/kubeca/certinit       (cached)
?       github.com/ekspand/trusty/kubeca/controller     [no test files]
ok      github.com/ekspand/trusty/pkg/awskmscrypto      (cached)
ok      github.com/ekspand/trusty/pkg/credentials       (cached)
ok      github.com/ekspand/trusty/pkg/csr       (cached)
ok      github.com/ekspand/trusty/pkg/gserver   (cached)
ok      github.com/ekspand/trusty/pkg/inmemcrypto       (cached)
ok      github.com/ekspand/trusty/pkg/jwt       (cached)
ok      github.com/ekspand/trusty/pkg/oauth2client      (cached)
ok      github.com/ekspand/trusty/pkg/poller    (cached)
ok      github.com/ekspand/trusty/pkg/print     (cached)
ok      github.com/ekspand/trusty/pkg/roles     (cached)
ok      github.com/ekspand/trusty/pkg/tlsutil   2.238s
ok      github.com/ekspand/trusty/pkg/transport (cached)
ok      github.com/ekspand/trusty/tests/mockpb  (cached)
?       github.com/ekspand/trusty/tests/testutils       [no test files]