### PR TITLE
For xdg-open use the equivalent built-in `open` command on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,5 @@ Add the launch configuration to .vscode/launch.json:
     make start-swagger
 
 Open http://localhost:8080
+
+Before runing the above command, make sure trusty is running locally using `bin/trusty` command.

--- a/cli/auth/auth.go
+++ b/cli/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	v1 "github.com/ekspand/trusty/api/v1"
@@ -50,7 +51,11 @@ func Authenticate(c ctl.Control, p interface{}) error {
 	}
 
 	if flags.NoBrowser == nil || !*flags.NoBrowser {
-		err = exec.Command("xdg-open", res.URL).Start()
+		execCommand := "xdg-open"
+		if runtime.GOOS == "darwin" {
+			execCommand = "open"
+		}
+		err = exec.Command(execCommand, res.URL).Start()
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
On MacOS it is not a trivial process to install xdg-open since it requires bunch of dependencies (e.g. https://superuser.com/questions/911735/how-do-i-use-xdg-open-from-xdg-utils-on-mac-osx). Instead on MacOS we can use the built-in `open` command to open the browser.