### PR TITLE
Add support for google oauth2 provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Add this to your ~/.profile
 ```.sh
 export TRUSTY_GITHUB_CLIENT_SECRET=0d...a8
 export TRUSTY_GITHUB_CLIENT_ID=09...71
+export TRUSTY_GOOGLE_CLIENT_SECRET=01...b2
+export TRUSTY_GOOGLE_CLIENT_ID=4a...89
 export TRUSTY_JWT_SEED=g...A
 # export CR_PAT=ghp_M...v
 ```

--- a/api/v1/path.go
+++ b/api/v1/path.go
@@ -73,6 +73,9 @@ const (
 
 	// PathForAuthGithubCallback is auth callback for github
 	PathForAuthGithubCallback = "/v1/auth/github/callback"
+
+	// PathForAuthGoogleCallback is auth callback for google
+	PathForAuthGoogleCallback = "/v1/auth/google/callback"
 )
 
 // Workflow service API

--- a/api/v1/workflow.go
+++ b/api/v1/workflow.go
@@ -6,6 +6,9 @@ const (
 	// ProviderGithub specifies name for Github
 	ProviderGithub = "github"
 
+	// ProviderGoogle specifies name for Google APIs
+	ProviderGoogle = "google"
+
 	// RoleAdmin specifies name for Admin role
 	RoleAdmin = "admin"
 )

--- a/backend/service/auth/testdata/google_user.json
+++ b/backend/service/auth/testdata/google_user.json
@@ -1,0 +1,5 @@
+{
+    "picture":"https://avatars0.gmail.com/u/1234920?v=4",
+    "email":"hayk.baluyan@gmail.com",
+    "name":"Hayk Baluyan"
+}

--- a/backend/service/auth/testdata/requests.json
+++ b/backend/service/auth/testdata/requests.json
@@ -1,4 +1,6 @@
 {
     "/login/oauth/access_token" : {"file":"token"},
-    "/user" : {"file":"user"}
+    "/user" : {"file":"user"},
+    "/token"  : {"file":"token"},
+    "/userinfo/v2/me?alt=json&prettyPrint=false" : {"file":"google_user"}
 }

--- a/cli/auth/auth.go
+++ b/cli/auth/auth.go
@@ -19,6 +19,7 @@ import (
 // AuthenticateFlags defines flags for Authenticate command
 type AuthenticateFlags struct {
 	NoBrowser *bool
+	Provider  *string
 }
 
 // Authenticate starts authentication
@@ -43,8 +44,12 @@ func Authenticate(c ctl.Control, p interface{}) error {
 		httpClient.WithTLS(tlscfg)
 	}
 
+	if flags.Provider == nil || *flags.Provider == "" {
+		return errors.New("please specify --provider parameter")
+	}
+
 	res := new(v1.AuthStsURLResponse)
-	path := fmt.Sprintf("/v1/auth/url?redirect_url=%s/v1/auth/done&device_id=%s", srv, hn)
+	path := fmt.Sprintf("%s?redirect_url=%s/v1/auth/done&device_id=%s&provider=%s", v1.PathForAuthURL, srv, hn, *flags.Provider)
 	_, _, err := httpClient.Request(context.Background(), "GET", []string{srv}, path, nil, res)
 	if err != nil {
 		return errors.Trace(err)
@@ -59,7 +64,7 @@ func Authenticate(c ctl.Control, p interface{}) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		fmt.Fprintf(cli.Writer(), "openning auth URL in browser: %s\n", res.URL)
+		fmt.Fprintf(cli.Writer(), "opening auth URL in browser: %s\n", res.URL)
 	} else {
 		fmt.Fprintf(cli.Writer(), "open auth URL in browser:\n%s\n", res.URL)
 	}

--- a/cli/auth/auth_test.go
+++ b/cli/auth/auth_test.go
@@ -31,7 +31,8 @@ func (s *testSuite) TestAuth() {
 	s.Cli.WithServer(server.URL)
 
 	disableBrowser := true
-	err := s.Run(auth.Authenticate, &auth.AuthenticateFlags{NoBrowser: &disableBrowser})
+	provider := "github"
+	err := s.Run(auth.Authenticate, &auth.AuthenticateFlags{NoBrowser: &disableBrowser, Provider: &provider})
 	s.Require().NoError(err)
 	s.HasText("open auth URL in browser:\n")
 }

--- a/cmd/trustyctl/main.go
+++ b/cmd/trustyctl/main.go
@@ -15,13 +15,6 @@ import (
 	"github.com/go-phorce/dolly/xlog"
 )
 
-var logger = xlog.NewPackageLogger("github.com/ekspand/trusty/cmd", "trustyctl")
-
-const (
-	rcError   = 1
-	rcSuccess = 0
-)
-
 func main() {
 	// Logs are set to os.Stderr, while output to os.Stdout
 	rc := realMain(os.Args, os.Stdout, os.Stderr)
@@ -68,6 +61,7 @@ func realMain(args []string, out io.Writer, errout io.Writer) ctl.ReturnCode {
 		PreAction(cli.PopulateControl).
 		Action(cli.RegisterAction(auth.Authenticate, loginFlags))
 	loginFlags.NoBrowser = cmdLogin.Flag("no-browser", "disable openning in browser").Bool()
+	loginFlags.Provider = cmdLogin.Flag("provider", "oauth2 provider, should be github or google").Default("github").String()
 
 	// ca: issuers|profile|sign|certs|revoked|publish_crl
 

--- a/etc/dev/oauth-google.yaml
+++ b/etc/dev/oauth-google.yaml
@@ -1,0 +1,10 @@
+---
+provider_id: google
+client_id: env://TRUSTY_GOOGLE_CLIENT_ID
+client_secret: env://TRUSTY_GOOGLE_CLIENT_SECRET
+scopes: 
+  - https://www.googleapis.com/auth/userinfo.email
+  - https://www.googleapis.com/auth/userinfo.profile
+response_type: code
+auth_url: https://accounts.google.com/o/oauth2/v2/auth
+token_url: https://oauth2.googleapis.com/token

--- a/etc/dev/trusty-config.yaml
+++ b/etc/dev/trusty-config.yaml
@@ -75,6 +75,7 @@ sql:
 # the configuration files for OAuth clients    
 oauth_clients:
   - oauth-github.yaml
+  - oauth-google.yaml
 
 authority: ca-config.dev.yaml
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,9 @@ type Configuration struct {
 	// Github specifies the configuration for Github client
 	Github Github `json:"github" yaml:"github"`
 
+	// Google specifies the configuration for Google client
+	Google Google `json:"google" yaml:"google"`
+
 	// OAuthClients specifies the configuration files for OAuth clients
 	OAuthClients []string `json:"oauth_clients" yaml:"oauth_clients"`
 }
@@ -85,5 +88,11 @@ type CryptoProv struct {
 // Github specifies the configuration for Github client
 type Github struct {
 	// BaseURL specifies the Github base URL.
+	BaseURL string `json:"base_url" yaml:"base_url"`
+}
+
+// Google specifies the configuration for Google client
+type Google struct {
+	// BaseURL specifies the Google base URL.
 	BaseURL string `json:"base_url" yaml:"base_url"`
 }

--- a/scripts/integration/docker-compose.tester.yml
+++ b/scripts/integration/docker-compose.tester.yml
@@ -80,6 +80,8 @@ services:
       - TRUSTY_JWT_SEED=testseed 
       - TRUSTY_GITHUB_CLIENT_ID=not_used_in_test
       - TRUSTY_GITHUB_CLIENT_SECRET=not_used_in_test
+      - TRUSTY_GOOGLE_CLIENT_ID=not_used_in_test
+      - TRUSTY_GOOGLE_CLIENT_SECRET=not_used_in_test
       - TRUSTY_SQL_CONN=host=10.77.88.100 port=5432 user=postgres password=postgres sslmode=disable dbname=trustydb
     entrypoint:
       - /bin/bash
@@ -149,6 +151,8 @@ services:
       - TRUSTY_JWT_SEED=testseed 
       - TRUSTY_GITHUB_CLIENT_ID=not_used_in_test
       - TRUSTY_GITHUB_CLIENT_SECRET=not_used_in_test
+      - TRUSTY_GOOGLE_CLIENT_ID=not_used_in_test
+      - TRUSTY_GOOGLE_CLIENT_SECRET=not_used_in_test
       - TRUSTY_SQL_CONN=host=10.77.88.100 port=5432 user=postgres password=postgres sslmode=disable dbname=trustydb
     entrypoint:
       - /bin/bash
@@ -204,6 +208,8 @@ services:
       - AWS_DEFAULT_REGION=us-west-2
       - TRUSTY_GITHUB_CLIENT_ID=not_used_in_test
       - TRUSTY_GITHUB_CLIENT_SECRET=not_used_in_test
+      - TRUSTY_GOOGLE_CLIENT_ID=not_used_in_test
+      - TRUSTY_GOOGLE_CLIENT_SECRET=not_used_in_test
       - TRUSTY_JWT_SEED=testseed 
     entrypoint:
       - /bin/bash


### PR DESCRIPTION
usage:

```
bin/trustyctl login --server https://localhost:7891 -r etc/dev/roots/trusty_dev_root_ca.pem --provider google
```

extra variables:

```
env | grep GOOGLE
TRUSTY_GOOGLE_CLIENT_ID=*****
TRUSTY_GOOGLE_CLIENT_SECRET=*****
```

```
....
test-runner_1   |               }
test-runner_1   |       ]
test-runner_1   | }
test-runner_1   | *** trusty intergation tests succeeded
trusty-ci_test-runner_1 exited with code 0
Aborting on container exit...
````