### PR TITLE
Add FCC endpoints to get FRN and Contact Email

### DIFF
--- a/api/v1/fcc.go
+++ b/api/v1/fcc.go
@@ -1,0 +1,11 @@
+package v1
+
+// FccFrnResponse provides response for https://apps.fcc.gov/cgb/form499/499results.cfm?FilerID=<fillerID>&XML=TRUE
+type FccFrnResponse struct {
+	FRN string `json:"frn"`
+}
+
+// FccSearchDetailResponse provides response for https://apps.fcc.gov/coresWeb/searchDetail.do?frn=<fnr>
+type FccSearchDetailResponse struct {
+	Email string `json:"email"`
+}

--- a/api/v1/path.go
+++ b/api/v1/path.go
@@ -146,4 +146,10 @@ const (
 	// Verbs: GET
 	// Response: SearchOpenCorporatesResponse
 	PathForMartiniSearchCorps = "/v1/ms/search/opencorporates"
+
+	// PathForMartiniGetFrn is path to get company FRN (Registration Number -CORESID)
+	PathForMartiniGetFrn = "/v1/ms/fcc_frn"
+
+	// PathForMartiniSearchDetail is path to get company details
+	PathForMartiniSearchDetail = "/v1/ms/fcc_search_detail"
 )

--- a/api/v1/path_test.go
+++ b/api/v1/path_test.go
@@ -22,4 +22,7 @@ func TestPaths(t *testing.T) {
 
 	assert.Equal(t, "/v1/wf", v1.PathForWorkflow)
 	assert.Equal(t, "/v1/wf/:provider/repos", v1.PathForWorkflowRepos)
+
+	assert.Equal(t, "/v1/ms/fcc_frn", v1.PathForMartiniGetFrn)
+	assert.Equal(t, "/v1/ms/fcc_search_detail", v1.PathForMartiniSearchDetail)
 }

--- a/backend/service/martini/fcc.go
+++ b/backend/service/martini/fcc.go
@@ -1,0 +1,62 @@
+package martini
+
+import (
+	"net/http"
+
+	"github.com/ekspand/trusty/api"
+	v1 "github.com/ekspand/trusty/api/v1"
+	"github.com/ekspand/trusty/pkg/fcc"
+	"github.com/go-phorce/dolly/rest"
+	"github.com/go-phorce/dolly/xhttp/httperror"
+	"github.com/go-phorce/dolly/xhttp/marshal"
+)
+
+// GetFrnHandler handles v1.PathForMartiniGetFrn
+func (s *Service) GetFrnHandler() rest.Handle {
+	return func(w http.ResponseWriter, r *http.Request, _ rest.Params) {
+		filerID := api.GetQueryString(r.URL, "filer_id")
+		if filerID == "" {
+			marshal.WriteJSON(w, r, httperror.WithInvalidRequest("missing filer_id parameter"))
+			return
+		}
+		fccClient := fcc.NewAPIClient(s.FccBaseURL)
+		frn, err := fccClient.GetFRN(filerID)
+		if err != nil {
+			logger.Errorf("filerID=%q, err=%q", filerID, err.Error())
+			marshal.WriteJSON(w, r, httperror.WithInvalidRequest("unable to get FRN response"))
+			return
+		}
+		res := v1.FccFrnResponse{
+			FRN: frn,
+		}
+
+		logger.Tracef("filerID=%q, frn=%q", filerID, frn)
+		marshal.WriteJSON(w, r, res)
+	}
+}
+
+// SearchDetailHandler handles v1.PathForMartiniSearchDetail
+func (s *Service) SearchDetailHandler() rest.Handle {
+	return func(w http.ResponseWriter, r *http.Request, _ rest.Params) {
+		frn := api.GetQueryString(r.URL, "frn")
+		if frn == "" {
+			marshal.WriteJSON(w, r, httperror.WithInvalidRequest("missing frn parameter"))
+			return
+		}
+		fccClient := fcc.NewAPIClient(s.FccBaseURL)
+		email, err := fccClient.GetEmail(frn)
+		if err != nil {
+			logger.Errorf("frn=%q, err=%q", frn, err.Error())
+			marshal.WriteJSON(w, r, httperror.WithInvalidRequest("unable to get email response"))
+			return
+		}
+
+		res := v1.FccSearchDetailResponse{
+			Email: email,
+		}
+
+		logger.Tracef("frn=%q, email=%q", frn, email)
+
+		marshal.WriteJSON(w, r, res)
+	}
+}

--- a/backend/service/martini/fcc_test.go
+++ b/backend/service/martini/fcc_test.go
@@ -1,0 +1,113 @@
+package martini_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	v1 "github.com/ekspand/trusty/api/v1"
+	"github.com/ekspand/trusty/backend/service/martini"
+	"github.com/go-phorce/dolly/testify/servefiles"
+	"github.com/go-phorce/dolly/xhttp/marshal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_FccFrnHandler(t *testing.T) {
+	service := trustyServer.Service(martini.ServiceName).(*martini.Service)
+	require.NotNil(t, service)
+
+	h := service.GetFrnHandler()
+
+	server := servefiles.New(t)
+	server.SetBaseDirs("testdata")
+
+	u, err := url.Parse(server.URL() + "/")
+	require.NoError(t, err)
+
+	service.FccBaseURL = u.Scheme + "://" + u.Host
+
+	t.Run("no_filer_id", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest(http.MethodGet, v1.PathForMartiniGetFrn, nil)
+		require.NoError(t, err)
+
+		h(w, r, nil)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, "{\"code\":\"invalid_request\",\"message\":\"missing filer_id parameter\"}", w.Body.String())
+	})
+
+	t.Run("wrong_filer_id", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest(http.MethodGet, v1.PathForMartiniGetFrn+"?filer_id=wrong", nil)
+		require.NoError(t, err)
+
+		h(w, r, nil)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, "{\"code\":\"invalid_request\",\"message\":\"unable to get FRN response\"}", w.Body.String())
+	})
+
+	t.Run("url", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest(http.MethodGet, v1.PathForMartiniGetFrn+"?filer_id=831188", nil)
+		require.NoError(t, err)
+
+		h(w, r, nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res v1.FccFrnResponse
+		require.NoError(t, marshal.Decode(w.Body, &res))
+		require.NotNil(t, res)
+		assert.Equal(t, "0024926677", res.FRN)
+	})
+}
+
+func Test_FccSearchDetailHandler(t *testing.T) {
+	service := trustyServer.Service(martini.ServiceName).(*martini.Service)
+	require.NotNil(t, service)
+
+	h := service.SearchDetailHandler()
+
+	server := servefiles.New(t)
+	server.SetBaseDirs("testdata")
+
+	u, err := url.Parse(server.URL() + "/")
+	require.NoError(t, err)
+
+	service.FccBaseURL = u.Scheme + "://" + u.Host
+
+	t.Run("no_frn", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest(http.MethodGet, v1.PathForMartiniSearchDetail, nil)
+		require.NoError(t, err)
+
+		h(w, r, nil)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, "{\"code\":\"invalid_request\",\"message\":\"missing frn parameter\"}", w.Body.String())
+	})
+
+	t.Run("wrong_frn", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest(http.MethodGet, v1.PathForMartiniSearchDetail+"?frn=wrong", nil)
+		require.NoError(t, err)
+
+		h(w, r, nil)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, "{\"code\":\"invalid_request\",\"message\":\"unable to get email response\"}", w.Body.String())
+	})
+
+	t.Run("url", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r, err := http.NewRequest(http.MethodGet, v1.PathForMartiniSearchDetail+"?frn=0024926677", nil)
+		require.NoError(t, err)
+
+		h(w, r, nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res v1.FccSearchDetailResponse
+		require.NoError(t, marshal.Decode(w.Body, &res))
+		require.NotNil(t, res)
+		assert.Equal(t, "tara.lyle@veracitynetworks.com", res.Email)
+	})
+}

--- a/backend/service/martini/martini_service.go
+++ b/backend/service/martini/martini_service.go
@@ -16,6 +16,8 @@ var logger = xlog.NewPackageLogger("github.com/ekspand/trusty/backend/service", 
 
 // Service defines the Status service
 type Service struct {
+	FccBaseURL string
+
 	server *gserver.Server
 	cfg    *config.Configuration
 	db     orgsdb.OrgsDb
@@ -56,4 +58,7 @@ func (s *Service) Close() {
 // RegisterRoute adds the Status API endpoints to the overall URL router
 func (s *Service) RegisterRoute(r rest.Router) {
 	r.GET(v1.PathForMartiniSearchCorps, s.SearchCorpsHandler())
+
+	r.GET(v1.PathForMartiniGetFrn, s.GetFrnHandler())
+	r.GET(v1.PathForMartiniSearchDetail, s.SearchDetailHandler())
 }

--- a/backend/service/martini/martini_test.go
+++ b/backend/service/martini/martini_test.go
@@ -73,8 +73,7 @@ func TestMain(m *testing.M) {
 	container, err := appcontainer.NewContainerFactory(nil).
 		WithConfigurationProvider(func() (*config.Configuration, error) {
 			return cfg, nil
-		}).
-		CreateContainerWithDependencies()
+		}).CreateContainerWithDependencies()
 	if err != nil {
 		panic(errors.Trace(err))
 	}

--- a/backend/service/martini/testdata/frn.xml
+++ b/backend/service/martini/testdata/frn.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Filer499QueryResults xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://apps.fcc.gov/cgb/form499/XMLSchema/Filer499QueryResults_Schema.xsd"
+ Updated="2021-06-21" RecordCount="1" >
+		
+        <Filer>
+            <Form_499_ID>831188</Form_499_ID>
+            <Filer_ID_Info>
+                <Registration_Current_as_of>2021-04-01</Registration_Current_as_of>
+                <start_date>2015-01-12</start_date>
+                <USF_Contributor>Yes</USF_Contributor>
+                <Legal_Name>LOW LATENCY COMMUNICATIONS LLC</Legal_Name>
+                <Principal_Communications_Type>Interconnected VoIP</Principal_Communications_Type>
+                <holding_company>IPIFONY SYSTEMS INC.</holding_company>
+                <FRN>0024926677</FRN>
+                <hq_address>
+                    <address_line>241 APPLEGATE TRACE</address_line>
+                    <city>PELHAM</city>
+                    <state>AL</state>
+                    <zip_code>35124</zip_code>
+                </hq_address>
+                <customer_inquiries_address>
+                    <address_line>241 APPLEGATE TRACE</address_line>
+                    <city>PELHAM</city>
+                    <state>AL</state>
+                    <zip_code>35124</zip_code>
+                </customer_inquiries_address>
+                <Customer_Inquiries_telephone>2057453970</Customer_Inquiries_telephone>
+                <other_trade_name>Low Latency Communications</other_trade_name>
+                <other_trade_name>String by Low Latency</other_trade_name>
+                <other_trade_name>Lilac by Low Latency</other_trade_name>
+            </Filer_ID_Info>
+            <Agent_for_Service_Of_Process>
+                <dc_agent>Jonathan Allen Rini O&apos;Neil, PC</dc_agent>
+                <dc_agent_telephone>2029553933</dc_agent_telephone>
+                <dc_agent_fax>2022962014</dc_agent_fax>
+                <dc_agent_email>jallen@rinioneil.com</dc_agent_email>
+                <dc_agent_address>
+                    <address_line>1200 New Hampshire Ave, NW</address_line>
+                    <address_line>Suite 600</address_line>
+                    <city>Washington</city>
+                    <state>DC</state>
+                    <zip_code>20036</zip_code>
+                </dc_agent_address>
+            </Agent_for_Service_Of_Process>
+            <FCC_Registration_information>
+                <Chief_Executive_Officer>Daryl Russo</Chief_Executive_Officer>
+                <Chairman_or_Senior_Officer>Matthew Hardeman</Chairman_or_Senior_Officer>
+                <President_or_Senior_Officer>Larry Smith</President_or_Senior_Officer>
+            </FCC_Registration_information>
+            <jurisdiction_state>alabama</jurisdiction_state>
+            <jurisdiction_state>florida</jurisdiction_state>
+            <jurisdiction_state>georgia</jurisdiction_state>
+            <jurisdiction_state>illinois</jurisdiction_state>
+            <jurisdiction_state>louisiana</jurisdiction_state>
+            <jurisdiction_state>north_carolina</jurisdiction_state>
+            <jurisdiction_state>pennsylvania</jurisdiction_state>
+            <jurisdiction_state>tennessee</jurisdiction_state>
+            <jurisdiction_state>texas</jurisdiction_state>
+            <jurisdiction_state>virginia</jurisdiction_state>
+        </Filer>
+</Filer499QueryResults>

--- a/backend/service/martini/testdata/requests.json
+++ b/backend/service/martini/testdata/requests.json
@@ -1,0 +1,4 @@
+{
+    "/cgb/form499/499results.cfm?FilerID=831188&XML=TRUE" : {"file":"frn.xml"},
+    "/coresWeb/searchDetail.do?frn=0024926677" : {"file":"search_detail.html"}
+}

--- a/backend/service/martini/testdata/search_detail.html
+++ b/backend/service/martini/testdata/search_detail.html
@@ -1,0 +1,147 @@
+<html>
+
+<head>
+	<title>FCC Registration System</title>
+	<link rel="stylesheet" type="text/css" href="images/registration/cores.css">
+</head>
+
+<body>
+
+<div id="srchDetailContent">
+
+
+<div id="srchDetailClose"><a href="javascript:self.close()">Close Window</a></div>
+
+
+<div id="srchDetailHeader">Registration Detail</div>       
+
+<table>
+
+<tr>
+	<th>FRN:</th>
+	<td>0000010827</td>
+</tr>
+
+<tr>
+	<th>Registration Date:</th>
+	<td>09/15/2000 08:30:58 AM</td>
+</tr>
+
+<tr>
+	<th>Last Updated:</th>
+	<td>
+	          	
+		04/05/2021 12:12:43 PM
+	</td>
+</tr>
+
+<tr>
+	<th>Business Name:</th>
+	<td>	
+	
+		Veracity Networks, LLC
+	
+	</td>
+</tr>
+
+<!-- <##dba##> -->
+
+<tr>
+	<th>Business Type:</th>
+	<td>
+	          	
+		Private Sector
+										
+	
+	,
+										
+	          	
+		Limited Liability Corporation
+	
+	</td>
+</tr>
+
+<tr>
+	<th>Contact Organization:</th>
+	<td>
+	          	
+		
+										
+	</td>
+</tr>
+
+<tr>
+	<th>Contact Position:</th>
+	<td>
+	          	
+		FCC Contact
+										
+	</td>
+</tr>
+<tr>
+	<th>Contact Name:</th>
+	<td>
+
+	
+	    Tara Lyle 
+	
+
+	</td>
+</tr>
+
+<tr>
+	<th>Contact Address:</th>
+	<td>
+	  
+	
+	
+357 S. 670 W.<br>
+       
+
+Ste 300<br>
+       
+
+Lindon, UT 84042<br>
+       
+       
+
+United States                                      
+                                            
+
+	
+	</td>
+</tr>
+
+<tr>
+	<th>Contact Email:</th>
+	<td>
+	          	
+		tara.lyle@veracitynetworks.com
+	
+	</td>
+</tr>
+
+<tr>
+	<th>ContactPhone:</th>
+	<td >
+	          	
+		(801) 878-3225 
+	
+	</td>
+</tr>
+
+<tr>
+	<th>ContactFax:</th>
+	<td>
+	          	
+		(801) 373-0682
+										
+	</td>
+</tr>
+
+</table>
+
+</div> <!-- Close srchDetailContent -->
+
+</body>
+</html>

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	cloud.google.com/go v0.86.0
+	github.com/PuerkitoBio/goquery v1.7.1 // indirect
 	github.com/aws/aws-sdk-go v1.38.66
 	github.com/cloudflare/cfssl v1.6.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
@@ -37,7 +38,7 @@ require (
 	go.uber.org/dig v1.10.0
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
-	golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
 	golang.org/x/tools v0.1.4
 	google.golang.org/api v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
+github.com/PuerkitoBio/goquery v1.7.1 h1:oE+T06D+1T7LNrn91B4aERsRIeCLJ/oPSa6xB9FPnz4=
+github.com/PuerkitoBio/goquery v1.7.1/go.mod h1:XY0pP4kfraEmmV1O7Uf6XyjoslwsneBbgeDjLYuN8xY=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
@@ -86,6 +88,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/andybalholm/cascadia v1.2.0 h1:vuRCkM5Ozh/BfmsaTm26kbjm0mIOM3yS5Ek/F5h18aE=
+github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/arrow v0.0.0-20200601151325-b2287a20f230/go.mod h1:QNYViu/X0HXDHw7m3KXzWSVXIbfUvJqBFe6Gj8/pYA0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -972,6 +976,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420 h1:a8jGStKg0XqKDlKqjLrXn0ioF5MH36pT7Z0BRTqLhbk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/internal/appcontainer/appcontainer.go
+++ b/internal/appcontainer/appcontainer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ekspand/trusty/internal/db/cadb"
 	"github.com/ekspand/trusty/internal/db/orgsdb"
 	"github.com/ekspand/trusty/pkg/awskmscrypto"
+	"github.com/ekspand/trusty/pkg/fcc"
 	"github.com/ekspand/trusty/pkg/gcpkmscrypto"
 	"github.com/ekspand/trusty/pkg/jwt"
 	"github.com/ekspand/trusty/pkg/oauth2client"
@@ -59,6 +60,9 @@ type ProvideCaDbFn func(cfg *config.Configuration) (cadb.CaDb, error)
 // ProvideClientFactoryFn defines client.Facroty provider
 type ProvideClientFactoryFn func(cfg *config.Configuration) (client.Factory, error)
 
+// ProvideFCCAPIClientFn defines FCC API Client provider
+type ProvideFCCAPIClientFn func() (fcc.APIClient, error)
+
 // CloseRegistrator provides interface to release resources on close
 type CloseRegistrator interface {
 	OnClose(closer io.Closer)
@@ -79,6 +83,7 @@ type ContainerFactory struct {
 	oauthProvider         ProvideOAuthClientsFn
 	jwtProvider           ProvideJwtFn
 	clientFactoryProvider ProvideClientFactoryFn
+	fccAPIClientProvider  ProvideFCCAPIClientFn
 }
 
 // NewContainerFactory returns an instance of ContainerFactory

--- a/pkg/fcc/fcc.go
+++ b/pkg/fcc/fcc.go
@@ -1,0 +1,178 @@
+package fcc
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/go-phorce/dolly/xhttp/retriable"
+	"github.com/juju/errors"
+	"golang.org/x/net/html/charset"
+)
+
+const (
+	fccDefaultBaseURL = "https://apps.fcc.gov"
+	emailHeader       = "Contact Email:"
+)
+
+// APIClient for FCC related API calls
+type APIClient interface {
+	GetFRN(filerID string) (string, error)
+	GetEmail(frn string) (string, error)
+}
+
+type apiClientImpl struct {
+	FccBaseURL string
+}
+
+// filer499QueryResults implements Filer499QueryResults interface
+type filer499QueryResults struct {
+	XMLName xml.Name `xml:"Filer499QueryResults"`
+	Filers  []filer  `xml:"Filer"`
+}
+
+// filer struct
+type filer struct {
+	XMLName     xml.Name    `xml:"Filer"`
+	Form499ID   string      `xml:"Form_499_ID"`
+	FilerIDInfo filerIDInfo `xml:"Filer_ID_Info"`
+}
+
+// filerIDInfo struct
+type filerIDInfo struct {
+	XMLName                     xml.Name `xml:"Filer_ID_Info"`
+	RegistrationCurrentAsOf     string   `xml:"Registration_Current_as_of"`
+	StartDate                   fccDate  `xml:"start_date"`
+	USFContributor              string   `xml:"USF_Contributor"`
+	LegalName                   string   `xml:"Legal_Name"`
+	PrincipalCommunicationsType string   `xml:"Principal_Communications_Type"`
+	HoldingCompany              string   `xml:"holding_company"`
+	FRN                         string   `xml:"FRN"`
+}
+
+// fccDate struct is custom implementation of date to be able to parse yyyy-mm-dd formal
+// FCC API returns dates in yyyy-mm-dd format that default golang XML decoder does not recognize
+type fccDate struct {
+	time.Time
+}
+
+func (c *fccDate) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	const shortForm = "2006-01-02"
+	var v string
+	d.DecodeElement(&v, &start)
+	parse, err := time.Parse(shortForm, v)
+	if err != nil {
+		return err
+	}
+	*c = fccDate{parse}
+	return nil
+}
+
+type fccResponseWriter struct {
+	data []byte
+}
+
+func (w *fccResponseWriter) Write(data []byte) (int, error) {
+	w.data = append(w.data, data...)
+	return len(data), nil
+}
+
+// NewAPIClient create new api client for FCC operations
+func NewAPIClient(baseURL string) APIClient {
+	c := apiClientImpl{
+		FccBaseURL: baseURL,
+	}
+	if c.FccBaseURL == "" {
+		c.FccBaseURL = fccDefaultBaseURL
+	}
+	return c
+}
+
+func (c apiClientImpl) GetFRN(filerID string) (string, error) {
+	httpClient := retriable.New()
+	resFromFcc := new(fccResponseWriter)
+	path := fmt.Sprintf("/cgb/form499/499results.cfm?FilerID=%s&XML=TRUE", filerID)
+	_, statusCode, err := httpClient.Request(context.Background(), "GET", []string{c.FccBaseURL}, path, nil, resFromFcc)
+	if err != nil {
+		return "", errors.Annotatef(err, "failed to execute request, url=%q, path=%q", c.FccBaseURL, path)
+	}
+
+	if statusCode >= 400 {
+		return "", errors.Annotatef(err, "failed to execute request, url=%q, path=%q, statusCode=%d", c.FccBaseURL, path, statusCode)
+	}
+
+	frn, err := ParseFRNFromXML(resFromFcc.data)
+	if err != nil {
+		return "", errors.New("failed to parse FRN from XML")
+	}
+
+	return frn, nil
+}
+
+func (c apiClientImpl) GetEmail(frn string) (string, error) {
+	httpClient := retriable.New()
+
+	resFromFcc := new(fccResponseWriter)
+	path := fmt.Sprintf("/coresWeb/searchDetail.do?frn=%s", frn)
+	_, _, err := httpClient.Request(context.Background(), "GET", []string{c.FccBaseURL}, path, nil, resFromFcc)
+	if err != nil {
+		return "", errors.Annotatef(err, "failed to execute request, url=%q, path=%q", c.FccBaseURL, path)
+	}
+
+	email, err := ParseEmailFromHTML(resFromFcc.data)
+	if err != nil {
+		return "", errors.Annotatef(err, "failed to parse email from XML result")
+	}
+	return email, nil
+}
+
+// ParseEmailFromHTML parses email from HTML returned by FCC search detail API
+func ParseEmailFromHTML(b []byte) (string, error) {
+	var heading string
+	var email string
+	reader := bytes.NewReader(b)
+	doc, err := goquery.NewDocumentFromReader(reader)
+	if err != nil {
+		return "", errors.New("failed to parse email from XML")
+	}
+
+	// Find each table
+	doc.Find("table").Each(func(index int, tablehtml *goquery.Selection) {
+		tablehtml.Find("tr").Each(func(indextr int, rowhtml *goquery.Selection) {
+			rowhtml.Find("th").Each(func(indexth int, tableheading *goquery.Selection) {
+				heading = tableheading.Text()
+			})
+
+			if heading == emailHeader {
+				rowhtml.Find("td").Each(func(indexth int, tablecell *goquery.Selection) {
+					email = tablecell.Text()
+				})
+			}
+		})
+	})
+
+	return strings.TrimSpace(email), nil
+}
+
+// ParseFRNFromXML parses frn from XML returned by FCC FRN API
+func ParseFRNFromXML(b []byte) (string, error) {
+	reader := bytes.NewReader(b)
+	decoder := xml.NewDecoder(reader)
+	decoder.CharsetReader = charset.NewReaderLabel
+	var fQueryResults filer499QueryResults
+	err := decoder.Decode(&fQueryResults)
+	if err != nil {
+		return "", errors.Annotatef(err, "failed to unmarshal xml FRN from XML")
+	}
+
+	if fQueryResults.Filers == nil || len(fQueryResults.Filers) == 0 {
+		return "", errors.New("failed to parse FRN from XML")
+	}
+	filersResult := fQueryResults.Filers[0]
+	filerIDInfo := filersResult.FilerIDInfo
+	return filerIDInfo.FRN, nil
+}

--- a/pkg/fcc/fcc_test.go
+++ b/pkg/fcc/fcc_test.go
@@ -1,0 +1,235 @@
+package fcc_test
+
+import (
+	"testing"
+
+	"github.com/ekspand/trusty/pkg/fcc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var htmlTest string = `
+<html>
+
+<head>
+	<title>FCC Registration System</title>
+	<link rel="stylesheet" type="text/css" href="images/registration/cores.css">
+</head>
+
+<body>
+
+<div id="srchDetailContent">
+
+
+<div id="srchDetailClose"><a href="javascript:self.close()">Close Window</a></div>
+
+
+<div id="srchDetailHeader">Registration Detail</div>       
+
+<table>
+
+<tr>
+	<th>FRN:</th>
+	<td>0000010827</td>
+</tr>
+
+<tr>
+	<th>Registration Date:</th>
+	<td>09/15/2000 08:30:58 AM</td>
+</tr>
+
+<tr>
+	<th>Last Updated:</th>
+	<td>
+	          	
+		04/05/2021 12:12:43 PM
+	</td>
+</tr>
+
+<tr>
+	<th>Business Name:</th>
+	<td>	
+	
+		Veracity Networks, LLC
+	
+	</td>
+</tr>
+
+<!-- <##dba##> -->
+
+<tr>
+	<th>Business Type:</th>
+	<td>
+	          	
+		Private Sector
+										
+	
+	,
+										
+	          	
+		Limited Liability Corporation
+	
+	</td>
+</tr>
+
+<tr>
+	<th>Contact Organization:</th>
+	<td>
+	          	
+		
+										
+	</td>
+</tr>
+
+<tr>
+	<th>Contact Position:</th>
+	<td>
+	          	
+		FCC Contact
+										
+	</td>
+</tr>
+<tr>
+	<th>Contact Name:</th>
+	<td>
+
+	
+	    Tara Lyle 
+	
+
+	</td>
+</tr>
+
+<tr>
+	<th>Contact Address:</th>
+	<td>
+	  
+	
+	
+357 S. 670 W.<br>
+       
+
+Ste 300<br>
+       
+
+Lindon, UT 84042<br>
+       
+       
+
+United States                                      
+                                            
+
+	
+	</td>
+</tr>
+
+<tr>
+	<th>Contact Email:</th>
+	<td>
+	          	
+		tara.lyle@veracitynetworks.com
+	
+	</td>
+</tr>
+
+<tr>
+	<th>ContactPhone:</th>
+	<td >
+	          	
+		(801) 878-3225 
+	
+	</td>
+</tr>
+
+<tr>
+	<th>ContactFax:</th>
+	<td>
+	          	
+		(801) 373-0682
+										
+	</td>
+</tr>
+
+</table>
+
+</div> <!-- Close srchDetailContent -->
+
+</body>
+</html>
+`
+
+func TestParseEmailFromHTML(t *testing.T) {
+	email, err := fcc.ParseEmailFromHTML([]byte(htmlTest))
+	require.NoError(t, err)
+	assert.Equal(t, "tara.lyle@veracitynetworks.com", email)
+}
+
+var xmlForTest string = `
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<Filer499QueryResults xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://apps.fcc.gov/cgb/form499/XMLSchema/Filer499QueryResults_Schema.xsd"
+ Updated="2021-06-21" RecordCount="1" >
+		
+        <Filer>
+            <Form_499_ID>831188</Form_499_ID>
+            <Filer_ID_Info>
+                <Registration_Current_as_of>2021-04-01</Registration_Current_as_of>
+                <start_date>2015-01-12</start_date>
+                <USF_Contributor>Yes</USF_Contributor>
+                <Legal_Name>LOW LATENCY COMMUNICATIONS LLC</Legal_Name>
+                <Principal_Communications_Type>Interconnected VoIP</Principal_Communications_Type>
+                <holding_company>IPIFONY SYSTEMS INC.</holding_company>
+                <FRN>0024926677</FRN>
+                <hq_address>
+                    <address_line>241 APPLEGATE TRACE</address_line>
+                    <city>PELHAM</city>
+                    <state>AL</state>
+                    <zip_code>35124</zip_code>
+                </hq_address>
+                <customer_inquiries_address>
+                    <address_line>241 APPLEGATE TRACE</address_line>
+                    <city>PELHAM</city>
+                    <state>AL</state>
+                    <zip_code>35124</zip_code>
+                </customer_inquiries_address>
+                <Customer_Inquiries_telephone>2057453970</Customer_Inquiries_telephone>
+                <other_trade_name>Low Latency Communications</other_trade_name>
+                <other_trade_name>String by Low Latency</other_trade_name>
+                <other_trade_name>Lilac by Low Latency</other_trade_name>
+            </Filer_ID_Info>
+            <Agent_for_Service_Of_Process>
+                <dc_agent>Jonathan Allen Rini O&apos;Neil, PC</dc_agent>
+                <dc_agent_telephone>2029553933</dc_agent_telephone>
+                <dc_agent_fax>2022962014</dc_agent_fax>
+                <dc_agent_email>jallen@rinioneil.com</dc_agent_email>
+                <dc_agent_address>
+                    <address_line>1200 New Hampshire Ave, NW</address_line>
+                    <address_line>Suite 600</address_line>
+                    <city>Washington</city>
+                    <state>DC</state>
+                    <zip_code>20036</zip_code>
+                </dc_agent_address>
+            </Agent_for_Service_Of_Process>
+            <FCC_Registration_information>
+                <Chief_Executive_Officer>Daryl Russo</Chief_Executive_Officer>
+                <Chairman_or_Senior_Officer>Matthew Hardeman</Chairman_or_Senior_Officer>
+                <President_or_Senior_Officer>Larry Smith</President_or_Senior_Officer>
+            </FCC_Registration_information>
+            <jurisdiction_state>alabama</jurisdiction_state>
+            <jurisdiction_state>florida</jurisdiction_state>
+            <jurisdiction_state>georgia</jurisdiction_state>
+            <jurisdiction_state>illinois</jurisdiction_state>
+            <jurisdiction_state>louisiana</jurisdiction_state>
+            <jurisdiction_state>north_carolina</jurisdiction_state>
+            <jurisdiction_state>pennsylvania</jurisdiction_state>
+            <jurisdiction_state>tennessee</jurisdiction_state>
+            <jurisdiction_state>texas</jurisdiction_state>
+            <jurisdiction_state>virginia</jurisdiction_state>
+        </Filer>
+</Filer499QueryResults>
+`
+
+func TestParseFRNFromXML(t *testing.T) {
+	frn, err := fcc.ParseFRNFromXML([]byte(xmlForTest))
+	require.NoError(t, err)
+	assert.Equal(t, "0024926677", frn)
+}


### PR DESCRIPTION
Two new endpoints are introduced:

/v1/fcc/frn?filer_id=_filer_id_ 

for example https://localhost:7891/v1/fcc/frn?filer_id=831188

expected response

```
{"FRN":"0024926677"}
```

/v1/fcc/search_detail?frn=_frn_

for example https://localhost:7891/v1/fcc/search_detail?frn=0024926677

expected response

```
{"Email":"mhardeman@lowlatencycomm.com"}
```